### PR TITLE
fix: example overflow large screens

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,9 +58,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 visible: false,
                 child: child,
               ),
-              child: _croppedImage != null
-                  ? RawImage(image: _croppedImage)
-                  : Image(image: _imageProvider),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height - 70,
+                ),
+                child: _croppedImage != null
+                    ? RawImage(image: _croppedImage)
+                    : Image(image: _imageProvider),
+              ),
             ),
             TextButton(
               onPressed: () async {


### PR DESCRIPTION
Hi @kekland, thanks for adding this package, it is a really useful addition especially on web where `croppie` in `image_cropper` can sometimes have strange rendering issues.

I ran the example and noticed that there can be an overflow on larger screens

![Bildschirmfoto 2023-05-17 um 08 18 36](https://github.com/kekland/croppy/assets/13286425/30849a5e-5934-4001-b14e-5b7026a901b5)

So I simply constrained the height to be maxHeight less than roughly 70 of text buttons

![Bildschirmfoto 2023-05-17 um 08 21 05](https://github.com/kekland/croppy/assets/13286425/78214b88-7ae9-4047-878a-26826ffa9972)

If the example UI is updated later, a more robust solution could be added. This seems fine for now.