### PR TITLE
Just an idea for improved color handling

### DIFF
--- a/lib/src/model/croppable_image_data.dart
+++ b/lib/src/model/croppable_image_data.dart
@@ -13,11 +13,13 @@ class CroppableImageData extends Equatable {
     required this.baseTransformations,
     required this.imageTransform,
     required this.currentImageTransform,
+    this.overlayColor,
   });
 
   CroppableImageData.initial({
     required this.imageSize,
     required this.cropShape,
+    this.overlayColor,
   })  : cropRect = Rect.fromLTWH(0, 0, imageSize.width, imageSize.height),
         imageTransform = Matrix4.identity(),
         currentImageTransform = Matrix4.identity(),
@@ -26,6 +28,7 @@ class CroppableImageData extends Equatable {
   CroppableImageData.initialWithCropPathFn({
     required this.imageSize,
     required CropShapeFn cropPathFn,
+    this.overlayColor,
   })  : cropRect = Rect.fromLTWH(0, 0, imageSize.width, imageSize.height),
         cropShape = cropPathFn(
           vg.globalPathBuilder,
@@ -38,6 +41,7 @@ class CroppableImageData extends Equatable {
   static Future<CroppableImageData> fromImageProvider(
     ImageProvider imageProvider, {
     CropShapeFn cropPathFn = aabbCropShapeFn,
+    Color? overlayColor,
   }) async {
     final image = await obtainImage(imageProvider);
     return CroppableImageData.initialWithCropPathFn(
@@ -46,6 +50,7 @@ class CroppableImageData extends Equatable {
         image.height.toDouble(),
       ),
       cropPathFn: cropPathFn,
+      overlayColor: overlayColor,
     );
   }
 
@@ -75,6 +80,10 @@ class CroppableImageData extends Equatable {
   ///
   /// This is set to [Matrix.identity] once a transformation is finished.
   final Matrix4 currentImageTransform;
+
+  /// The color to use for the overlay outside the crop area.
+  /// If null, a default color based on brightness will be used.
+  final Color? overlayColor;
 
   /// Translates the given [transformation] to the center of the image.
   Matrix4 translateTransformation(Matrix4 transformation) {
@@ -127,6 +136,7 @@ class CroppableImageData extends Equatable {
     BaseTransformations? baseTransformations,
     Matrix4? imageTransform,
     Matrix4? currentImageTransform,
+    Color? overlayColor,
   }) {
     return CroppableImageData(
       imageSize: imageSize ?? this.imageSize,
@@ -136,6 +146,7 @@ class CroppableImageData extends Equatable {
       currentImageTransform:
           currentImageTransform ?? this.currentImageTransform,
       baseTransformations: baseTransformations ?? this.baseTransformations,
+      overlayColor: overlayColor ?? this.overlayColor,
     );
   }
 

--- a/lib/src/pages/cupertino_pages.dart
+++ b/lib/src/pages/cupertino_pages.dart
@@ -36,7 +36,7 @@ import 'package:flutter/cupertino.dart';
 ///
 /// The [locale] is used to localize the UI. If not provided, the locale from
 /// the [WidgetsApp] is used.
-/// 
+///
 /// [showGestureHandlesOn] controls which crop shape types should show crop
 /// handles. By default, only AABB (rectangular) crop shapes show crop handles.
 ///
@@ -60,12 +60,17 @@ Future<CropImageResult?> showCupertinoImageCropper(
 }) async {
   late final CroppableImageData _initialData;
 
+  // Verwende eine Overlay-Farbe basierend auf dem Theme, wenn verfügbar
+  // 98% Opazität für stärkere Abdunkelung
+  final overlayColor = themeData?.scaffoldBackgroundColor.withOpacity(0.98);
+
   if (initialData != null) {
     _initialData = initialData;
   } else {
     _initialData = await CroppableImageData.fromImageProvider(
       imageProvider,
       cropPathFn: cropPathFn ?? aabbCropShapeFn,
+      overlayColor: overlayColor,
     );
   }
 
@@ -79,6 +84,7 @@ Future<CropImageResult?> showCupertinoImageCropper(
         cropShapeFn: cropPathFn,
         allowedAspectRatios: allowedAspectRatios,
         enabledTransformations: enabledTransformations,
+        overlayColor: overlayColor, // Übergebe die Theme-basierte Overlay-Farbe
         builder: (context, controller) => CupertinoImageCropperPage(
           heroTag: heroTag,
           showLoadingIndicatorOnSubmit: showLoadingIndicatorOnSubmit,

--- a/lib/src/pages/material_pages.dart
+++ b/lib/src/pages/material_pages.dart
@@ -36,7 +36,7 @@ import 'package:flutter/material.dart';
 ///
 /// The [locale] is used to localize the UI. If not provided, the locale from
 /// the [WidgetsApp] is used.
-/// 
+///
 /// /// [showGestureHandlesOn] controls which crop shape types should show crop
 /// handles. By default, only AABB (rectangular) crop shapes show crop handles.
 ///
@@ -59,6 +59,9 @@ Future<CropImageResult?> showMaterialImageCropper(
   List<CropShapeType> showGestureHandlesOn = const [CropShapeType.aabb],
 }) async {
   late final CroppableImageData _initialData;
+  
+  // Verwende eine Overlay-Farbe basierend auf dem Theme, wenn verfügbar
+  final overlayColor = themeData?.scaffoldBackgroundColor.withOpacity(0.98);
 
   if (initialData != null) {
     _initialData = initialData;
@@ -66,6 +69,7 @@ Future<CropImageResult?> showMaterialImageCropper(
     _initialData = await CroppableImageData.fromImageProvider(
       imageProvider,
       cropPathFn: cropPathFn ?? aabbCropShapeFn,
+      overlayColor: overlayColor,
     );
   }
 
@@ -79,6 +83,7 @@ Future<CropImageResult?> showMaterialImageCropper(
         cropShapeFn: cropPathFn,
         allowedAspectRatios: allowedAspectRatios,
         enabledTransformations: enabledTransformations,
+        overlayColor: overlayColor, // Übergebe die Theme-basierte Overlay-Farbe
         builder: (context, controller) => MaterialImageCropperPage(
           heroTag: heroTag,
           controller: controller,

--- a/lib/src/widgets/common/croppable_image_widget.dart
+++ b/lib/src/widgets/common/croppable_image_widget.dart
@@ -3,6 +3,7 @@
 import 'package:croppy/src/src.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/cupertino.dart';
 
 /// TODO: Document this
 class CroppableImageWidget
@@ -232,8 +233,11 @@ class CroppableImageRenderObject extends RenderBox
               // Avoids some anti-aliasing artifacts
               (offset & imageData.imageSize).inflate(0.5),
               Paint()
-                ..color = Colors.black.withOpacity(backgroundOpacity)
-                ..blendMode = BlendMode.multiply,
+                ..color =
+                    imageData.overlayColor?.withOpacity(backgroundOpacity) ??
+                        const Color(0xFF000000)
+                            .withOpacity(backgroundOpacity * 0.98)
+                ..blendMode = BlendMode.srcOver,
             );
           },
           oldLayer: _backgroundTransformLayer.layer,

--- a/lib/src/widgets/cupertino/cupertino_image_cropper_app_bar.dart
+++ b/lib/src/widgets/cupertino/cupertino_image_cropper_app_bar.dart
@@ -23,8 +23,8 @@ class CupertinoImageCropperAppBar extends StatelessWidget
               horizontal: 16.0,
               vertical: 10.0,
             ),
-            child: const CupertinoFlipHorizontalIcon(
-              color: CupertinoColors.systemGrey2,
+            child: CupertinoFlipHorizontalIcon(
+              color: CupertinoTheme.of(context).primaryContrastingColor,
               size: 24.0,
             ),
           ),
@@ -36,9 +36,9 @@ class CupertinoImageCropperAppBar extends StatelessWidget
               horizontal: 16.0,
               vertical: 10.0,
             ),
-            child: const Icon(
+            child: Icon(
               CupertinoIcons.rotate_left_fill,
-              color: CupertinoColors.systemGrey2,
+              color: CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         const Spacer(),
@@ -68,7 +68,7 @@ class CupertinoImageCropperAppBar extends StatelessWidget
               child: CupertinoAspectRatioIcon(
                 color: toolbar == CupertinoCroppableImageToolbar.aspectRatio
                     ? CupertinoTheme.of(context).primaryColor
-                    : CupertinoColors.systemGrey2,
+                    : CupertinoTheme.of(context).primaryContrastingColor,
                 size: 24.0,
               ),
             ),

--- a/lib/src/widgets/cupertino/cupertino_image_cropper_bottom_app_bar.dart
+++ b/lib/src/widgets/cupertino/cupertino_image_cropper_bottom_app_bar.dart
@@ -30,7 +30,10 @@ class CupertinoImageCropperBottomAppBar extends StatelessWidget
             top: 16.0,
             bottom: 16.0,
           ),
-          child: Text(l10n.cancelLabel),
+          child: Text(
+            l10n.cancelLabel,
+            style: TextStyle(color: primaryColor),
+          ),
         ),
         const Spacer(),
         FutureButton(

--- a/lib/src/widgets/cupertino/default_cupertino_croppable_image_controller.dart
+++ b/lib/src/widgets/cupertino/default_cupertino_croppable_image_controller.dart
@@ -6,11 +6,14 @@ class DefaultCupertinoCroppableImageController extends StatefulWidget {
     super.key,
     required this.builder,
     required this.imageProvider,
-    required this.initialData,
-    this.allowedAspectRatios,
+    this.initialData,
     this.postProcessFn,
     this.cropShapeFn,
+    this.allowedAspectRatios,
     this.enabledTransformations,
+    this.showLoadingIndicatorOnSubmit = false,
+    this.showGestureHandlesOn = const [CropShapeType.aabb],
+    this.overlayColor,
   });
 
   final ImageProvider imageProvider;
@@ -19,6 +22,9 @@ class DefaultCupertinoCroppableImageController extends StatefulWidget {
   final CropShapeFn? cropShapeFn;
   final List<CropAspectRatio?>? allowedAspectRatios;
   final List<Transformation>? enabledTransformations;
+  final bool showLoadingIndicatorOnSubmit;
+  final List<CropShapeType> showGestureHandlesOn;
+  final Color? overlayColor;
 
   final Widget Function(
     BuildContext context,
@@ -45,11 +51,20 @@ class _DefaultCupertinoCroppableImageControllerState
     late final CroppableImageData initialData;
 
     if (widget.initialData != null) {
-      initialData = widget.initialData!;
+      initialData = CroppableImageData(
+        imageSize: widget.initialData!.imageSize,
+        cropRect: widget.initialData!.cropRect,
+        cropShape: widget.initialData!.cropShape,
+        baseTransformations: widget.initialData!.baseTransformations,
+        imageTransform: widget.initialData!.imageTransform,
+        currentImageTransform: widget.initialData!.currentImageTransform,
+        overlayColor: widget.overlayColor,
+      );
     } else {
       initialData = await CroppableImageData.fromImageProvider(
         widget.imageProvider,
         cropPathFn: widget.cropShapeFn ?? aabbCropShapeFn,
+        overlayColor: widget.overlayColor,
       );
     }
 

--- a/lib/src/widgets/cupertino/handles/cupertino_image_crop_handles.dart
+++ b/lib/src/widgets/cupertino/handles/cupertino_image_crop_handles.dart
@@ -21,12 +21,26 @@ class CupertinoImageCropHandles extends StatelessWidget {
   final Color fineGuideColor;
 
   Widget _buildHandles(BuildContext context, bool areGuideLinesVisible) {
+    final primaryColor = CupertinoTheme.of(context).primaryColor;
+    final primaryContrastingColor =
+        CupertinoTheme.of(context).primaryContrastingColor;
+
+    final actualHandleColor =
+        handleColor == CupertinoColors.white ? primaryColor : handleColor;
+    final actualGuideColor = guideColor == CupertinoColors.white
+        ? primaryContrastingColor
+        : guideColor;
+    final actualFineGuideColor =
+        fineGuideColor == const Color.fromRGBO(255, 255, 255, 0.3)
+            ? primaryContrastingColor.withOpacity(0.3)
+            : fineGuideColor;
     final fineGuidesChild = AnimatedOpacity(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,
       opacity: controller.isRotating && areGuideLinesVisible ? 1.0 : 0.0,
       child: CustomPaint(
-        painter: _CupertinoImageCropperFineGuidesPainter(color: fineGuideColor),
+        painter: _CupertinoImageCropperFineGuidesPainter(
+            color: actualFineGuideColor),
       ),
     );
 
@@ -35,7 +49,7 @@ class CupertinoImageCropHandles extends StatelessWidget {
       curve: Curves.easeInOut,
       opacity: areGuideLinesVisible ? 1.0 : 0.0,
       child: CustomPaint(
-        painter: _CupertinoImageCropperGuidesPainter(guideColor),
+        painter: _CupertinoImageCropperGuidesPainter(actualGuideColor),
       ),
     );
 
@@ -47,7 +61,7 @@ class CupertinoImageCropHandles extends StatelessWidget {
         CustomPaint(
           painter: showGestureHandlesOn.contains(cropShape.type)
               ? _CupertinoImageRectCropHandlesPainter(
-                  handleColor,
+                  actualHandleColor,
                 )
               : _CupertinoImageCustomCropHandlesPainter(
                   cropShape: cropShape,

--- a/lib/src/widgets/cupertino/icons/cupertino_aspect_ratio_icon.dart
+++ b/lib/src/widgets/cupertino/icons/cupertino_aspect_ratio_icon.dart
@@ -22,7 +22,7 @@ class CupertinoAspectRatioIcon extends StatelessWidget {
           height: size * 0.7815940210098449,
           child: CustomPaint(
             painter: _CupertinoAspectRatioIconPainter(
-              color ?? CupertinoColors.white,
+              color ?? CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         ),

--- a/lib/src/widgets/cupertino/icons/cupertino_flip_horizontal_icon.dart
+++ b/lib/src/widgets/cupertino/icons/cupertino_flip_horizontal_icon.dart
@@ -23,7 +23,7 @@ class CupertinoFlipHorizontalIcon extends StatelessWidget {
           height: size * 0.8908227228633697,
           child: CustomPaint(
             painter: _CupertinoFlipHorizontalIconPainter(
-              color ?? CupertinoColors.white,
+              color ?? CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         ),

--- a/lib/src/widgets/cupertino/icons/cupertino_perspective_x_icon.dart
+++ b/lib/src/widgets/cupertino/icons/cupertino_perspective_x_icon.dart
@@ -22,7 +22,7 @@ class CupertinoPerspectiveXIcon extends StatelessWidget {
           height: size,
           child: CustomPaint(
             painter: _CupertinoPerspectiveXIconPainter(
-              color ?? CupertinoColors.white,
+              color ?? CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         ),

--- a/lib/src/widgets/cupertino/icons/cupertino_perspective_y_icon.dart
+++ b/lib/src/widgets/cupertino/icons/cupertino_perspective_y_icon.dart
@@ -22,7 +22,7 @@ class CupertinoPerspectiveYIcon extends StatelessWidget {
           height: size * 0.7310248486644371,
           child: CustomPaint(
             painter: _CupertinoPerspectiveYIconPainter(
-              color ?? CupertinoColors.white,
+              color ?? CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         ),

--- a/lib/src/widgets/cupertino/icons/cupertino_straighten_icon.dart
+++ b/lib/src/widgets/cupertino/icons/cupertino_straighten_icon.dart
@@ -21,7 +21,7 @@ class CupertinoStraightenIcon extends StatelessWidget {
           height: size * 0.7284062960242369,
           child: CustomPaint(
             painter: _CupertinoStraightenIconPainter(
-              color ?? CupertinoColors.white,
+              color ?? CupertinoTheme.of(context).primaryContrastingColor,
             ),
           ),
         ),

--- a/lib/src/widgets/cupertino/theme/cupertino_image_cropper_theme.dart
+++ b/lib/src/widgets/cupertino/theme/cupertino_image_cropper_theme.dart
@@ -4,8 +4,38 @@ import 'package:flutter/material.dart';
 
 CupertinoThemeData generateCupertinoImageCropperTheme(BuildContext context) {
   final materialTheme = generateMaterialImageCropperTheme(context);
+  final primaryColor = materialTheme.colorScheme.primary;
 
   return MaterialBasedCupertinoThemeData(materialTheme: materialTheme).copyWith(
     scaffoldBackgroundColor: kCupertinoImageCropperBackgroundColor,
+    primaryColor: primaryColor,
+    primaryContrastingColor: CupertinoColors.white,
+    barBackgroundColor: kCupertinoImageCropperBackgroundColor,
+    textTheme: CupertinoTextThemeData(
+      primaryColor: primaryColor,
+      textStyle: const TextStyle(
+        color: CupertinoColors.white,
+        fontSize: 16.0,
+      ),
+      actionTextStyle: TextStyle(
+        color: primaryColor,
+        fontSize: 16.0,
+        fontWeight: FontWeight.w600,
+      ),
+      navTitleTextStyle: const TextStyle(
+        color: CupertinoColors.white,
+        fontSize: 17.0,
+        fontWeight: FontWeight.w600,
+      ),
+      navActionTextStyle: TextStyle(
+        color: primaryColor, // Back button
+        fontSize: 17.0,
+      ),
+      navLargeTitleTextStyle: const TextStyle(
+        color: CupertinoColors.white,
+        fontSize: 34.0,
+        fontWeight: FontWeight.w700,
+      ),
+    ),
   );
 }

--- a/lib/src/widgets/cupertino/toolbar/cupertino_image_aspect_ratio_toolbar.dart
+++ b/lib/src/widgets/cupertino/toolbar/cupertino_image_aspect_ratio_toolbar.dart
@@ -174,16 +174,16 @@ class _CupertinoOrientationWidget extends StatelessWidget {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(2.0),
               border: Border.all(
-                color: CupertinoColors.systemGrey,
+                color: CupertinoTheme.of(context).primaryColor.withOpacity(0.7),
               ),
               color: isSelected
-                  ? CupertinoColors.systemGrey
-                  : CupertinoColors.darkBackgroundGray,
+                  ? CupertinoTheme.of(context).primaryColor
+                  : CupertinoTheme.of(context).barBackgroundColor,
             ),
             child: isSelected
-                ? const Icon(
+                ? Icon(
                     CupertinoIcons.checkmark_alt,
-                    color: CupertinoColors.darkBackgroundGray,
+                    color: CupertinoTheme.of(context).barBackgroundColor,
                     size: 18.0,
                   )
                 : null,
@@ -218,7 +218,7 @@ class _AspectRatioChipWidget extends StatelessWidget {
         height: 24.0,
         decoration: BoxDecoration(
           color:
-              isSelected ? CupertinoColors.white.withOpacity(0.2) : null,
+              isSelected ? CupertinoTheme.of(context).primaryColor.withOpacity(0.2) : null,
           borderRadius: BorderRadius.circular(12.0),
         ),
         padding: const EdgeInsets.symmetric(
@@ -230,8 +230,8 @@ class _AspectRatioChipWidget extends StatelessWidget {
           aspectRatio,
           style: TextStyle(
             color: isSelected
-                ? CupertinoColors.white
-                : CupertinoColors.systemGrey2,
+                ? CupertinoTheme.of(context).primaryContrastingColor
+                : CupertinoTheme.of(context).primaryColor,
             fontSize: 14.0,
           ),
         ),

--- a/lib/src/widgets/cupertino/toolbar/cupertino_image_transformation_toolbar.dart
+++ b/lib/src/widgets/cupertino/toolbar/cupertino_image_transformation_toolbar.dart
@@ -57,6 +57,9 @@ class _CupertinoImageTransformationToolbarState
           onChanged: (v) {
             widget.controller.onStraighten(angleRad: v);
           },
+          activeColor: CupertinoTheme.of(context).primaryColor,
+          inactiveColor: CupertinoTheme.of(context).textTheme.textStyle.color ??
+              CupertinoColors.systemGrey2,
         ),
       );
     }
@@ -74,6 +77,9 @@ class _CupertinoImageTransformationToolbarState
           onChanged: (v) {
             widget.controller.onRotateX(angleRad: v);
           },
+          activeColor: CupertinoTheme.of(context).primaryColor,
+          inactiveColor: CupertinoTheme.of(context).textTheme.textStyle.color ??
+              CupertinoColors.systemGrey2,
         ),
       );
     }
@@ -90,6 +96,9 @@ class _CupertinoImageTransformationToolbarState
           onChanged: (v) {
             widget.controller.onRotateY(angleRad: v);
           },
+          activeColor: CupertinoTheme.of(context).primaryColor,
+          inactiveColor: CupertinoTheme.of(context).textTheme.textStyle.color ??
+              CupertinoColors.systemGrey2,
         ),
       );
     }
@@ -107,8 +116,8 @@ class _CupertinoImageTransformationToolbarState
           isActive: _activeKnob == _Knob.rotateZ,
           onSelected: () => setState(() => _activeKnob = _Knob.rotateZ),
           onChanged: (v) => widget.controller.onStraighten(angleRad: v),
-          inactiveChild: const CupertinoStraightenIcon(
-            color: CupertinoColors.white,
+          inactiveChild: CupertinoStraightenIcon(
+            color: CupertinoTheme.of(context).primaryContrastingColor,
           ),
         ),
       if (widget.controller.isTransformationEnabled(Transformation.rotateX))
@@ -120,8 +129,8 @@ class _CupertinoImageTransformationToolbarState
           isActive: _activeKnob == _Knob.rotateX,
           onSelected: () => setState(() => _activeKnob = _Knob.rotateX),
           onChanged: (v) => widget.controller.onRotateX(angleRad: v),
-          inactiveChild: const CupertinoPerspectiveXIcon(
-            color: CupertinoColors.white,
+          inactiveChild: CupertinoPerspectiveXIcon(
+            color: CupertinoTheme.of(context).primaryContrastingColor,
           ),
         ),
       if (widget.controller.isTransformationEnabled(Transformation.rotateY))
@@ -132,8 +141,8 @@ class _CupertinoImageTransformationToolbarState
           isActive: _activeKnob == _Knob.rotateY,
           onSelected: () => setState(() => _activeKnob = _Knob.rotateY),
           onChanged: (v) => widget.controller.onRotateY(angleRad: v),
-          inactiveChild: const CupertinoPerspectiveYIcon(
-            color: CupertinoColors.white,
+          inactiveChild: CupertinoPerspectiveYIcon(
+            color: CupertinoTheme.of(context).primaryContrastingColor,
           ),
         ),
     ];

--- a/lib/src/widgets/cupertino/toolbar/cupertino_knob.dart
+++ b/lib/src/widgets/cupertino/toolbar/cupertino_knob.dart
@@ -22,9 +22,20 @@ class CupertinoKnobButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = isPositive
-        ? CupertinoTheme.of(context).primaryColor
-        : CupertinoColors.white;
+    final theme = CupertinoTheme.of(context);
+    final activeColor = theme.primaryColor;
+    final inactiveColor = theme.primaryContrastingColor;
+    final Color color;
+    if (isPositive) {
+      // Positiver Wert: Primärfarbe
+      color = activeColor;
+    } else if (!isActive) {
+      // Neutraler Wert (nicht aktiv): Kontrastfarbe
+      color = inactiveColor;
+    } else {
+      // Negativer Wert: Weiß (Cupertino-spezifisch)
+      color = CupertinoColors.white;
+    }
 
     return CupertinoButton(
       onPressed: onPressed,
@@ -42,7 +53,7 @@ class CupertinoKnobButton extends StatelessWidget {
             alignment: Alignment.center,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: Colors.black54,
+              color: theme.scaffoldBackgroundColor.withOpacity(0.5),
               border: Border.all(
                 width: 2.0,
                 color: color.withOpacity(0.35),
@@ -77,7 +88,7 @@ class CupertinoKnob extends StatelessWidget {
 
     final color = isPositive
         ? CupertinoTheme.of(context).primaryColor
-        : CupertinoColors.white;
+        : CupertinoTheme.of(context).primaryContrastingColor;
 
     late final Widget child;
 
@@ -103,6 +114,7 @@ class CupertinoKnob extends StatelessWidget {
       onPressed: () => onChanged(0.0),
       progressPainter: _CupertinoKnobProgressPainter(
         primaryColor: color,
+        inactiveColor: CupertinoTheme.of(context).primaryContrastingColor,
         value: value / extent,
       ),
       child: AnimatedSwitcher(
@@ -119,15 +131,17 @@ class _CupertinoKnobProgressPainter extends CustomPainter {
   _CupertinoKnobProgressPainter({
     required this.value,
     required this.primaryColor,
+    this.inactiveColor,
   });
 
   final Color primaryColor;
+  final Color? inactiveColor;
   final double value;
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = value > epsilon ? primaryColor : Colors.white
+      ..color = value > epsilon ? primaryColor : (inactiveColor ?? Colors.white)
       ..strokeWidth = 2.0
       ..style = PaintingStyle.stroke;
 

--- a/lib/src/widgets/cupertino/toolbar/cupertino_rotation_slider.dart
+++ b/lib/src/widgets/cupertino/toolbar/cupertino_rotation_slider.dart
@@ -13,6 +13,8 @@ class CupertinoRotationSlider extends StatefulWidget {
     required this.onStart,
     required this.onEnd,
     this.isReversed = false,
+    this.activeColor,
+    this.inactiveColor,
   });
 
   final double value;
@@ -21,6 +23,8 @@ class CupertinoRotationSlider extends StatefulWidget {
   final ValueChanged<double> onChanged;
   final VoidCallback onEnd;
   final bool isReversed;
+  final Color? activeColor;
+  final Color? inactiveColor;
 
   @override
   State<CupertinoRotationSlider> createState() =>
@@ -98,7 +102,8 @@ class _CupertinoRotationSliderState extends State<CupertinoRotationSlider> {
                       opacity: value.abs() > epsilon ? 1.0 : 0.5,
                       child: CustomPaint(
                         painter: _CupertinoSliderPainter(
-                          primaryColor: CupertinoTheme.of(context).primaryColor,
+                          primaryColor: widget.activeColor ?? CupertinoTheme.of(context).primaryColor,
+                          contrastingColor: widget.inactiveColor ?? CupertinoTheme.of(context).primaryContrastingColor,
                           value: value,
                           isDragging: _dragStartDetails != null,
                         ),
@@ -120,26 +125,28 @@ class _CupertinoSliderPainter extends CustomPainter {
     required this.primaryColor,
     required this.value,
     this.isDragging = false,
+    this.contrastingColor = CupertinoColors.white,
   });
 
   final Color primaryColor;
   final double value;
   final bool isDragging;
+  final Color contrastingColor;
 
   @override
   void paint(Canvas canvas, Size size) {
     final dividerPaint = Paint()
-      ..color = CupertinoColors.white.withOpacity(0.75)
+      ..color = contrastingColor.withOpacity(0.75)
       ..style = PaintingStyle.stroke
       ..strokeWidth = 0.0;
 
     final highlightedDividerPaint = Paint()
-      ..color = CupertinoColors.white
+      ..color = contrastingColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.0;
 
     final outOfBoundsDividerPaint = Paint()
-      ..color = CupertinoColors.white.withOpacity(0.25)
+      ..color = contrastingColor.withOpacity(0.25)
       ..style = PaintingStyle.stroke
       ..strokeWidth = 0.0;
 
@@ -175,11 +182,11 @@ class _CupertinoSliderPainter extends CustomPainter {
     canvas.drawCircle(
       Offset(center.dx, -8.0),
       3.0,
-      Paint()..color = CupertinoColors.white,
+      Paint()..color = contrastingColor,
     );
 
     final tickerPaint = Paint()
-      ..color = isDragging ? primaryColor : CupertinoColors.white
+      ..color = isDragging ? primaryColor : contrastingColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2.0;
 
@@ -193,6 +200,7 @@ class _CupertinoSliderPainter extends CustomPainter {
   @override
   bool shouldRepaint(_CupertinoSliderPainter oldDelegate) =>
       primaryColor != oldDelegate.primaryColor ||
+      contrastingColor != oldDelegate.contrastingColor ||
       value != oldDelegate.value ||
       isDragging != oldDelegate.isDragging;
 }

--- a/lib/src/widgets/material/default_material_croppable_image_controller.dart
+++ b/lib/src/widgets/material/default_material_croppable_image_controller.dart
@@ -11,6 +11,7 @@ class DefaultMaterialCroppableImageController extends StatefulWidget {
     this.postProcessFn,
     this.cropShapeFn,
     this.enabledTransformations,
+    this.overlayColor,
   });
 
   final ImageProvider imageProvider;
@@ -19,6 +20,7 @@ class DefaultMaterialCroppableImageController extends StatefulWidget {
   final CropShapeFn? cropShapeFn;
   final List<CropAspectRatio?>? allowedAspectRatios;
   final List<Transformation>? enabledTransformations;
+  final Color? overlayColor;
 
   final Widget Function(
     BuildContext context,
@@ -45,11 +47,20 @@ class _DefaultMaterialCroppableImageControllerState
     late final CroppableImageData initialData;
 
     if (widget.initialData != null) {
-      initialData = widget.initialData!;
+      initialData = CroppableImageData(
+        imageSize: widget.initialData!.imageSize,
+        cropRect: widget.initialData!.cropRect,
+        cropShape: widget.initialData!.cropShape,
+        baseTransformations: widget.initialData!.baseTransformations,
+        imageTransform: widget.initialData!.imageTransform,
+        currentImageTransform: widget.initialData!.currentImageTransform,
+        overlayColor: widget.overlayColor,
+      );
     } else {
       initialData = await CroppableImageData.fromImageProvider(
         widget.imageProvider,
         cropPathFn: widget.cropShapeFn ?? aabbCropShapeFn,
+        overlayColor: widget.overlayColor,
       );
     }
 


### PR DESCRIPTION
# Improved color handling in Croppy widget

This is a quick suggestion for improving color handling in the Croppy widget, especially for Cupertino components in light mode.

## Key changes:
- Added overlayColor parameter to enable theme-based colors for the crop area overlay
- Modified the overlay outside the crop area to use scaffoldBackgroundColor with 98% opacity instead of always being dark
- Replaced hardcoded colors in Cupertino components with theme-based alternatives
- Added color parameters to various components to enable better theming

<img width="490" alt="image" src="https://github.com/user-attachments/assets/a7c7e24f-7891-4079-9aea-9fef98f92e51" />  <img width="490" alt="image" src="https://github.com/user-attachments/assets/2dbf9ab5-06af-4478-a988-5ac2150cb170" />

***Here is an example in light mode before the changes***

<img width="490" alt="image" src="https://github.com/user-attachments/assets/1b1d13bb-f6ec-4469-95f6-3c0ba5e3413c" />

This implementation is just meant as a suggestion since I needed these features for a personal project. The code was implemented quickly and might not be as clean or optimized as it could be, but perhaps it can serve as inspiration for proper implementation.

The changes allow the widget to better adapt to different themes, particularly in light mode where the previous dark overlay didn't work well.

### Thank you for creating this excellent package - it's very helpful for my current project and will be valuable for future projects too! 🙏

## Detailed Changes

### lib/src/model/croppable_image_data.dart:
- Added overlayColor parameter to copyWith() method to properly preserve theme colors

### lib/src/widgets/common/croppable_image_widget.dart:
- Replaced hardcoded black overlay with theme-based overlay color (98% opacity)
- Unified fallback colors for consistent appearance in light/dark mode
- Changed blend mode to srcOver for better visibility

### lib/src/pages/cupertino_pages.dart:
- Increased overlay opacity to 98% for stronger darkening effect
- Added theme color extraction from scaffoldBackgroundColor

### lib/src/pages/material_pages.dart:
- Set consistent 98% overlay opacity
- Added theme color extraction from scaffoldBackgroundColor

### lib/src/widgets/cupertino/default_cupertino_croppable_image_controller.dart:
- Added overlayColor propagation when reusing initialData
- Fixed data inheritance to maintain theme colors

### lib/src/widgets/material/default_material_croppable_image_controller.dart:
- Added overlayColor propagation when reusing initialData
- Fixed data inheritance to maintain theme colors

### lib/src/widgets/cupertino/toolbar/cupertino_knob.dart:
- Implemented three-state color logic (positive, neutral, negative)
- Added semi-transparent background with scaffoldBackgroundColor (50% opacity)
- Used primaryColor for positive values and primaryContrastingColor for neutral/negative

### lib/src/widgets/cupertino/toolbar/cupertino_image_transformation_toolbar.dart:
- Applied theme-based colors to all sliders (active/inactive states)
- Used primaryColor for active state and textStyle color for inactive state

### lib/src/widgets/cupertino/handles/cupertino_image_crop_handles.dart:
- Applied theme colors to handles and guide lines
- Used primaryColor and primaryContrastingColor instead of hardcoded colors

### lib/src/widgets/cupertino/toolbar/cupertino_rotation_slider.dart:
- Added color parameters for different states
- Used theme colors for better visibility and state indication
- Applied consistent color scheme with other UI elements

### lib/src/widgets/cupertino/toolbar/cupertino_image_aspect_ratio_toolbar.dart:
- Applied theme-based colors for better visibility and consistency
- Improved active/inactive state indication
- Aligned with overall UI color scheme

### lib/src/widgets/cupertino/theme/cupertino_image_cropper_theme.dart:
- Integrated theme-based color handling
- Improved compatibility with light/dark mode
- Applied consistent color variables throughout theme

### lib/src/widgets/cupertino/icons/*:
- Applied uniform theme colors across all icons
- Used primaryContrastingColor for consistent appearance
- Improved visibility in both light and dark modes

### lib/src/widgets/cupertino/cupertino_image_cropper_app_bar.dart:
- Optimized color scheme for app bar icons
- Applied theme colors for better visibility
- Aligned with bottom app bar styling

### lib/src/widgets/cupertino/cupertino_image_cropper_bottom_app_bar.dart:
- Improved color handling for bottom bar elements
- Ensured consistency with the rest of the UI
- Applied theme-based colors for buttons and icons