### PR TITLE
compileSdkVersion, ndk, gradle update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.0
+
+* Updated `compileSdkVersion` to `36`
+* Updated `Gradle` to `8.13`
+* Updated `ndkVersion` to `27.0.12077973`
+* Updated `minSdkVersion` to `23`
+
+
 ## 1.3.6
 
 * Added a parameter called `showGestureHandlesOn` to control for which crop shapes the gesture handles should be shown. This allows you to, for example, show the rectangular gesture handles on a circular crop shape. Thanks @denysbohatyrov!

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.13.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
 
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.
-    ndkVersion "23.1.7779620"
+    ndkVersion "29.0.13113456 rc1"
 
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
@@ -56,6 +56,6 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 24
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
 
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
     // to bump the version in their app.
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
 
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.
-    ndkVersion "29.0.13113456 rc1"
+    ndkVersion "27.0.12077973"
 
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: croppy
 description: A fully customizable image cropper for Flutter. Mobile-first, but supports Web and Desktop platforms.
-version: 1.3.8
+version: 1.4.0
 homepage: https://github.com/kekland/croppy
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: croppy
 description: A fully customizable image cropper for Flutter. Mobile-first, but supports Web and Desktop platforms.
-version: 1.3.7
+version: 1.3.8
 homepage: https://github.com/kekland/croppy
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: croppy
 description: A fully customizable image cropper for Flutter. Mobile-first, but supports Web and Desktop platforms.
-version: 1.3.6
+version: 1.3.7
 homepage: https://github.com/kekland/croppy
 
 environment:


### PR DESCRIPTION
croppy is currently not usable on the current version of flutter.